### PR TITLE
Remove FastCraft API dependency.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: ProRecipes
 main: mc.mcgrizzz.prorecipes.ProRecipes
 version: 1.8.4
-softdepend: [TitleManager, FastCraft]
+softdepend: [TitleManager]
 commands:
     builditem:
         description: Build an item with a custom display name, and lore.

--- a/src/mc/mcgrizzz/prorecipes/ProRecipes.java
+++ b/src/mc/mcgrizzz/prorecipes/ProRecipes.java
@@ -86,7 +86,7 @@ public class ProRecipes extends JavaPlugin implements Listener{
 	public boolean title;
 	public boolean prompts;
 	public int wait;
-	boolean fastCraft, spigot, checkUpdate;
+	boolean spigot, checkUpdate;
 	
 	public Messages ms;
 	
@@ -161,9 +161,6 @@ public class ProRecipes extends JavaPlugin implements Listener{
 			}
 		}
 		
-		
-		fastCraft = false;
-		
 		ms = new Messages();
 		rec = new Recipes();
 		
@@ -174,9 +171,6 @@ public class ProRecipes extends JavaPlugin implements Listener{
 		console.sendMessage(ChatColor.DARK_GREEN + "Thank you for purchasing ProRecipes! \n" +  "Any comments or concerns message me on spigot!" + ChatColor.RESET);
 		 
 		title = getServer().getPluginManager().isPluginEnabled("TitleManager");
-		
-		
-		fastCraft = getServer().getPluginManager().isPluginEnabled("FastCraft");
 		
 		
 		

--- a/src/mc/mcgrizzz/prorecipes/RecipeBuilder.java
+++ b/src/mc/mcgrizzz/prorecipes/RecipeBuilder.java
@@ -19,8 +19,6 @@ import org.bukkit.metadata.FixedMetadataValue;
 import com.licel.stringer.annotations.insecure;
 import com.licel.stringer.annotations.secured;
 
-import co.kepler.fastcraft.api.FastCraftApi;
-
 public class RecipeBuilder implements Listener{
 	
 	//Used for backup
@@ -88,7 +86,6 @@ public class RecipeBuilder implements Listener{
 	
  	
 	public void openRecipeBuilder(final Player p, final String type){
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
 		ItemBuilder.close(p);
 		ItemBuilder.sendMessage(p, m.getMessage("Recipe_Builder_Title", ChatColor.GOLD + "Recipe Builder") , m.getMessage("Recipe_Builder_Insert", ChatColor.DARK_GREEN + "Insert the desired result"));
 		
@@ -107,7 +104,6 @@ public class RecipeBuilder implements Listener{
 	}
 	
 	private void openShapeless(final Player p) {
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
 		final ItemStack i = p.getOpenInventory().getItem(0).clone();
 		ItemBuilder.close(p);
 		p.setMetadata("closed", new FixedMetadataValue(ProRecipes.getPlugin(), ""));
@@ -129,7 +125,6 @@ public class RecipeBuilder implements Listener{
 	}
 
 	private void openShaped(final Player p) {
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
 		final ItemStack i = p.getOpenInventory().getItem(0).clone();
 		
 		ItemBuilder.close(p);
@@ -152,8 +147,6 @@ public class RecipeBuilder implements Listener{
 	}
 	
 	private void openFurnace(final Player p) {
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
 		final ItemStack i = p.getOpenInventory().getItem(0).clone();
 		
 		ItemBuilder.close(p);
@@ -192,9 +185,6 @@ public class RecipeBuilder implements Listener{
 	
 	
 	public void openChoice(final Player p) {
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
-		
 		ItemBuilder.close(p);
 		p.setMetadata("closed", new FixedMetadataValue(ProRecipes.getPlugin(), ""));
 		ItemBuilder.sendMessage(p, m.getMessage("Recipe_Builder_Title", ChatColor.GOLD + "Recipe Builder") ,  m.getMessage("Choose_Type", ChatColor.DARK_GREEN + "Choose the type of recipe"));
@@ -240,9 +230,6 @@ public class RecipeBuilder implements Listener{
 	}
 	
 	public void askPermission(final Player p){
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
-		
 		ItemBuilder.close(p);
 		p.setMetadata("closed", new FixedMetadataValue(ProRecipes.getPlugin(), ""));
 		ItemBuilder.sendMessage(p, m.getMessage("Recipe_Builder_Title", ChatColor.GOLD + "Recipe Builder") , m.getMessage("Choose_Permission", ChatColor.DARK_GREEN + "Type a permission. Type 'no' for no permission"));

--- a/src/mc/mcgrizzz/prorecipes/RecipeManager.java
+++ b/src/mc/mcgrizzz/prorecipes/RecipeManager.java
@@ -22,8 +22,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import com.licel.stringer.annotations.insecure;
 import com.licel.stringer.annotations.secured;
 
-import co.kepler.fastcraft.api.FastCraftApi;
-
 public class RecipeManager implements Listener {
 	
 	public HashMap<String, RecipeShaped> shaped = new HashMap<String, RecipeShaped>();
@@ -39,8 +37,6 @@ public class RecipeManager implements Listener {
 	}
 	
 	public void openRecipeManager(final Player p){
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
 		if(p.hasPermission("prorecipes.modifyrecipes")){
 			ItemBuilder.sendMessage(p, m.getMessage("Recipe_Viewer_Title", ChatColor.GOLD + "Recipe Manager"), 
 					m.getMessage("Recipe_Viewer_Prompt", ChatColor.DARK_GREEN + "View and manage recipes"));
@@ -92,8 +88,6 @@ public class RecipeManager implements Listener {
 	}
 	
 	private void openShaped(final Player p, final int page) {
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
 		//ItemBuilder.sendMessage(p, ChatColor.GOLD + "Recipe Manager", ChatColor.DARK_GREEN + "Click on a recipe to view and manage it");
 		
 		ProRecipes.getPlugin().getServer().getScheduler().runTaskLater(ProRecipes.getPlugin(), new Runnable(){
@@ -252,8 +246,6 @@ public class RecipeManager implements Listener {
 	}
 	
 	private void openFurnace(final Player p, final int page) {
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
 		//ItemBuilder.sendMessage(p, ChatColor.GOLD + "Recipe Manager", ChatColor.DARK_GREEN + "Click on a recipe to view and manage it");
 		
 		ProRecipes.getPlugin().getServer().getScheduler().runTaskLater(ProRecipes.getPlugin(), new Runnable(){
@@ -413,10 +405,6 @@ public class RecipeManager implements Listener {
 
 
 	private void openShapeless(final Player p, final int page) {
-		
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
-		
 		//ItemBuilder.sendMessage(p, ChatColor.GOLD + "Recipe Manager", ChatColor.DARK_GREEN + "Click on a recipe to view and manage it");
 		
 		ProRecipes.getPlugin().getServer().getScheduler().runTaskLater(ProRecipes.getPlugin(), new Runnable(){
@@ -571,10 +559,6 @@ public class RecipeManager implements Listener {
 	}
 	
 	private void openMulti(final Player p, final int page) {
-		
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
-		
 		//ItemBuilder.sendMessage(p, ChatColor.GOLD + "Recipe Manager", ChatColor.DARK_GREEN + "Click on a recipe to view and manage it");
 		
 		ProRecipes.getPlugin().getServer().getScheduler().runTaskLater(ProRecipes.getPlugin(), new Runnable(){
@@ -735,7 +719,6 @@ public class RecipeManager implements Listener {
 	
 	
 	private void confirmModify(final Player p, String title, final int type){
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
 		//0 = shapeless
 		//1 = shaped
 		//2 == furnace
@@ -1350,9 +1333,6 @@ public class RecipeManager implements Listener {
 	}
 	
 	public void askPermission(final Player p, String type){
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
-		
-		
 		ItemBuilder.close(p);
 		p.setMetadata("closed", new FixedMetadataValue(ProRecipes.getPlugin(), ""));
 		ItemBuilder.sendMessage(p, m.getMessage("Recipe_Viewer_Title", ChatColor.GOLD + "Recipe Manager"),  m.getMessage("Choose_Permission", ChatColor.DARK_GREEN + "Type a permission. Type 'no' for no permission"));
@@ -1362,10 +1342,7 @@ public class RecipeManager implements Listener {
 	}
 	
 	public void openRecipeInfo(final Player p, int slot, int type){
-		
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
 		ItemBuilder.close(p);
-		if(ProRecipes.getPlugin().fastCraft){FastCraftApi.allowCraftingInvToOpen(p);}
 		p.openWorkbench(null, true);
 		if(type == 3){
 			p.openInventory(ProRecipes.getPlugin().getRecipes().createMultiTable(p, 3));


### PR DESCRIPTION
FastCraft used to open whenever a crafting inventory opened, which sometimes caused issues when other plugins wanted to open a normal crafting table. The API had a method to allow crafting inventories to open to prevent this issue. Now FastCraft opens when a player right clicks a crafting table. Because of this, those issues are gone, the FastCraft API is no longer needed.